### PR TITLE
Validate account operations and improve tests

### DIFF
--- a/conta_bancaria.py
+++ b/conta_bancaria.py
@@ -10,6 +10,8 @@ Uso rápido:
 
 from __future__ import annotations
 
+import math
+
 
 class ContaBancaria:
     """Modelo simples de conta bancária com encapsulamento do saldo.
@@ -37,15 +39,23 @@ class ContaBancaria:
         return self._saldo
 
     def depositar(self, valor: float) -> None:
-        """Adiciona um valor positivo ao saldo."""
-        if valor <= 0:
-            raise ValueError("Valor do depósito deve ser positivo.")
+        """Adiciona um valor ao saldo.
+
+        Levanta ``ValueError`` se ``valor`` não for um número finito
+        estritamente positivo.
+        """
+        if not isinstance(valor, (int, float)) or not math.isfinite(valor) or valor <= 0:
+            raise ValueError("Valor do depósito deve ser um número finito positivo.")
         self._saldo += float(valor)
 
     def sacar(self, valor: float) -> bool:
-        """Saca um valor, caso haja saldo suficiente. Retorna True se o saque foi realizado."""
-        if valor <= 0:
-            raise ValueError("Valor do saque deve ser positivo.")
+        """Saca um valor, caso haja saldo suficiente.
+
+        Retorna ``True`` se o saque for realizado e levanta ``ValueError``
+        para valores que não sejam números finitos positivos.
+        """
+        if not isinstance(valor, (int, float)) or not math.isfinite(valor) or valor <= 0:
+            raise ValueError("Valor do saque deve ser um número finito positivo.")
         if valor > self._saldo:
             return False
         self._saldo -= float(valor)

--- a/tests/test_conta_bancaria.py
+++ b/tests/test_conta_bancaria.py
@@ -29,16 +29,16 @@ def test_deposito_e_saque_basico(capsys):
     assert saida == "Saldo atual de Fulano: R$ 120.00"
 
 
-def test_deposito_invalido():
+@pytest.mark.parametrize("valor", [0, -10, float("nan"), float("inf")])
+def test_deposito_invalido(valor: float) -> None:
     c = ContaBancaria("Fulano")
-    for valor in (0, -10):
-        with pytest.raises(ValueError):
-            c.depositar(valor)
+    with pytest.raises(ValueError):
+        c.depositar(valor)
 
 
-def test_saque_invalido_ou_insuficiente():
+def test_saque_invalido_ou_insuficiente() -> None:
     c = ContaBancaria("Fulano", 10)
-    for valor in (0, -5):
+    for valor in (0, -5, float("nan"), float("inf")):
         with pytest.raises(ValueError):
             c.sacar(valor)
     assert c.sacar(20) is False  # saldo insuficiente

--- a/tests/test_veiculos.py
+++ b/tests/test_veiculos.py
@@ -11,7 +11,7 @@ def carregar_modulo():
     raiz = Path(__file__).resolve().parents[1]
     # Localiza o arquivo ignorando possíveis problemas de codificação no nome
     candidatos = list(raiz.glob("Program*Orientada-a-Objetos.py"))
-    assert candidatos, "Arquivo de POO nao encontrado (pattern Program*Orientada-a-Objetos.py)"
+    assert candidatos, "Arquivo de POO não encontrado (pattern Program*Orientada-a-Objetos.py)"
     caminho = candidatos[0]
     spec = importlib.util.spec_from_file_location("poo_veiculos", caminho)
     assert spec and spec.loader


### PR DESCRIPTION
## Summary
- Validate deposit and withdraw inputs to reject non-numeric or non-finite values
- Clarify docstrings for `depositar` and `sacar`
- Improve test coverage and fix typo in vehicle module message

## Testing
- `python -m pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bcbdeb2564832e9f9abf7ced0af618